### PR TITLE
Develop branch aligned with master

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -55,3 +55,15 @@ jobs:
           committer_email: actions@github.com
           default_author: user_info
           message: 'gh-action: updated compiled files and bumped version to ${{ env.VERSION }}'
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: Checkout develop branch
+        run: git checkout develop
+
+      - name: Merge master into develop
+        run: git pull origin master --no-ff
+
+      - name: Push changes to develop
+        run: git push origin develop


### PR DESCRIPTION
In order to lock/protect `master` and `develop` branches we must keep `develop` up to date with `master`.

<!-- GIT-BOARD-CONFIG-START 
{
    "results": [
        {
            "id": "LinkPullRequestProjectUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request was linked to `https://github.com/orgs/landamessenger/projects/2`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was temporarily updated to `master`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description was temporarily modified to include a reference to issue **#32**."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was reverted to its original value: `develop`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The temporary issue reference **#32** was removed from the description."
            ],
            "reminders": []
        }
    ],
    "branchType": "feature"
}
GIT-BOARD-CONFIG-END -->