### PR TITLE
Develop branch aligned with master

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: [ self-hosted, Linux ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Switch to SSH
         run: git remote set-url origin git@gitboardflow.github.com:landamessenger/git-board-flow.git
@@ -59,8 +61,14 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
+      - name: Pull master
+        run: git pull origin master
+
       - name: Checkout develop branch
         run: git checkout develop
+
+      - name: Pull develop
+        run: git pull origin develop
 
       - name: Merge master into develop
         run: git pull origin master --no-ff


### PR DESCRIPTION
In order to lock/protect `master` and `develop` branches we must keep `develop` up to date with `master`.


<!-- GIT-BOARD-CONFIG-START 
{
    "results": [
        {
            "id": "LinkPullRequestProjectUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request was linked to `https://github.com/orgs/landamessenger/projects/2`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was temporarily updated to `master`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description was temporarily modified to include a reference to issue **#32**."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was reverted to its original value: `develop`."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The temporary issue reference **#32** was removed from the description."
            ],
            "reminders": []
        }
    ],
    "branchType": "feature"
}
GIT-BOARD-CONFIG-END -->