### PR TITLE
Develop branch aligned with master

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -55,3 +55,15 @@ jobs:
           committer_email: actions@github.com
           default_author: user_info
           message: 'gh-action: updated compiled files and bumped version to ${{ env.VERSION }}'
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: Checkout develop branch
+        run: git checkout develop
+
+      - name: Merge master into develop
+        run: git pull origin master --no-ff
+
+      - name: Push changes to develop
+        run: git push origin develop

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: [ self-hosted, Linux ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Switch to SSH
         run: git remote set-url origin git@gitboardflow.github.com:landamessenger/git-board-flow.git
@@ -59,8 +61,14 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
+      - name: Pull master
+        run: git pull origin master
+
       - name: Checkout develop branch
         run: git checkout develop
+
+      - name: Pull develop
+        run: git pull origin develop
 
       - name: Merge master into develop
         run: git pull origin master --no-ff


### PR DESCRIPTION
To lock/protect `master` and `develop` branches we must keep `develop` up to date with `master`.
