### PR TITLE
Auto-assign Reviewers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ inputs:
     description: "Reopens a closed issue when changes are pushed to the branch associated with the issue."
     default: "true"
   desired-assignees-count:
-    description: "The number of assignees desired for the issue or pull request. If set to 0, no assignees will be added. If the number exceeds the available members, all members will be assigned."
+    description: "The number of assignees desired for the issue or pull request. If set to 0, no assignees will be added. If the number exceeds the available members, all members will be assigned. Max 10."
     default: "1"
   desired-reviewers-count:
     description: "The number of reviewers desired for the pull request. If set to 0, no reviewers will be added. If the number exceeds the available members, all members will be reviewers. Max 15."

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,9 @@ inputs:
   desired-assignees-count:
     description: "The number of assignees desired for the issue or pull request. If set to 0, no assignees will be added. If the number exceeds the available members, all members will be assigned."
     default: "1"
+  desired-reviewers-count:
+    description: "The number of reviewers desired for the pull request. If set to 0, no reviewers will be added. If the number exceeds the available members, all members will be reviewers. Max 15."
+    default: "1"
   github-token:
     description: "GitHub token for branch and project operations within the repository scope."
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -33001,12 +33001,24 @@ class LinkPullRequestProjectUseCase {
             for (const project of param.projects) {
                 const actionDone = await this.projectRepository.linkContentId(project, param.pullRequest.id, param.tokens.tokenPat);
                 if (actionDone) {
+                    let currentProject = await this.projectRepository.getProjectDetail(project.url, param.tokens.tokenPat);
+                    if (currentProject === undefined) {
+                        result.push(new result_1.Result({
+                            id: this.taskId,
+                            success: false,
+                            executed: true,
+                            steps: [
+                                `Tried to link the pull request to [\`${project.url}\`](${project.url}) but there was a problem.`,
+                            ]
+                        }));
+                        continue;
+                    }
                     result.push(new result_1.Result({
                         id: this.taskId,
                         success: true,
                         executed: true,
                         steps: [
-                            `The pull request was linked to \`${project.url}\`.`,
+                            `The pull request was linked to [**${currentProject?.title}**](${currentProject?.url}).`,
                         ],
                         error: core_1.error,
                     }));

--- a/src/data/model/pull_request.ts
+++ b/src/data/model/pull_request.ts
@@ -2,6 +2,7 @@ import * as github from "@actions/github";
 
 export class PullRequest {
     desiredAssigneesCount: number;
+    desiredReviewersCount: number;
 
     get action(): string {
         return github.context.payload.action ?? '';
@@ -51,7 +52,9 @@ export class PullRequest {
 
     constructor(
         desiredAssigneesCount: number,
+        desiredReviewersCount: number,
     ) {
         this.desiredAssigneesCount = desiredAssigneesCount;
+        this.desiredReviewersCount = desiredReviewersCount;
     }
 }

--- a/src/data/usecase/pull_request_link_use_case.ts
+++ b/src/data/usecase/pull_request_link_use_case.ts
@@ -6,6 +6,7 @@ import {LinkPullRequestIssueUseCase} from "./steps/link_pull_request_issue_use_c
 import * as core from '@actions/core';
 import {CloseIssueUseCase} from "./steps/close_issue_use_case";
 import {AssignMemberToIssueUseCase} from "./steps/assign_members_to_issue_use_case";
+import {AssignReviewersToIssueUseCase} from "./steps/assign_reviewers_to_issue_use_case";
 
 export class PullRequestLinkUseCase implements ParamUseCase<Execution, Result[]> {
     taskId: string = 'PullRequestLinkUseCase';
@@ -24,6 +25,11 @@ export class PullRequestLinkUseCase implements ParamUseCase<Execution, Result[]>
                  * Assignees
                  */
                 results.push(...await new AssignMemberToIssueUseCase().invoke(param));
+
+                /**
+                 * Reviewers
+                 */
+                results.push(...await new AssignReviewersToIssueUseCase().invoke(param));
 
                 /**
                  * Link Pull Request to projects

--- a/src/data/usecase/steps/assign_reviewers_to_issue_use_case.ts
+++ b/src/data/usecase/steps/assign_reviewers_to_issue_use_case.ts
@@ -1,0 +1,122 @@
+import {ParamUseCase} from "../base/param_usecase";
+import {Execution} from "../../model/execution";
+import {IssueRepository} from "../../repository/issue_repository";
+import {ProjectRepository} from "../../repository/project_repository";
+import * as core from "@actions/core";
+import {Result} from "../../model/result";
+import {PullRequestRepository} from "../../repository/pull_request_repository";
+
+export class AssignReviewersToIssueUseCase implements ParamUseCase<Execution, Result[]> {
+    taskId: string = 'AssignReviewersToIssueUseCase';
+    private issueRepository = new IssueRepository();
+    private pullRequestRepository = new PullRequestRepository();
+    private projectRepository = new ProjectRepository();
+
+    async invoke(param: Execution): Promise<Result[]> {
+        core.info(`Executing ${this.taskId}.`)
+
+        const desiredReviewersCount = param.pullRequest.desiredReviewersCount
+        const number = param.pullRequest.number
+
+        const result: Result[] = []
+
+        try {
+            core.info(`#${number} needs ${desiredReviewersCount} reviewers.`)
+
+            const currentReviewers = await this.pullRequestRepository.getCurrentReviewers(
+                param.owner,
+                param.repo,
+                number,
+                param.tokens.token,
+            )
+
+            const currentAssignees = await this.issueRepository.getCurrentAssignees(
+                param.owner,
+                param.repo,
+                number,
+                param.tokens.token,
+            )
+
+            if (currentReviewers.length >= desiredReviewersCount) {
+                /**
+                 * No more assignees needed
+                 */
+                result.push(
+                    new Result({
+                        id: this.taskId,
+                        success: true,
+                        executed: true,
+                    })
+                )
+                return result
+            }
+
+            const missingReviewers = desiredReviewersCount - currentReviewers.length
+            core.info(`#${number} needs ${missingReviewers} more reviewers.`)
+
+
+            const excludeForReview: string[] = []
+            excludeForReview.push(...currentReviewers)
+            excludeForReview.push(...currentAssignees)
+
+            const members = await this.projectRepository.getRandomMembers(
+                param.owner,
+                missingReviewers,
+                excludeForReview,
+                param.tokens.tokenPat,
+            )
+
+            if (members.length === 0) {
+                result.push(
+                    new Result({
+                        id: this.taskId,
+                        success: false,
+                        executed: true,
+                        steps: [
+                            `Tried to assign members as reviewers to pull request, but no one was found.`,
+                        ],
+                    })
+                )
+                return result
+            }
+
+            const membersAdded = await this.pullRequestRepository.addReviewersToPullRequest(
+                param.owner,
+                param.repo,
+                number,
+                members,
+                param.tokens.token,
+            )
+
+            for (const member of membersAdded) {
+                if (members.indexOf(member) > -1)
+                    result.push(
+                        new Result({
+                            id: this.taskId,
+                            success: true,
+                            executed: true,
+                            steps: [
+                                `@${member} was requested to review the pull request.`,
+                            ],
+                        })
+                    )
+            }
+
+            return result;
+        } catch (error) {
+            console.error(error);
+            result.push(
+                new Result({
+                    id: this.taskId,
+                    success: false,
+                    executed: true,
+                    steps: [
+                        `Tried to assign members to issue.`,
+                    ],
+                    error: error,
+                })
+            )
+        }
+        return result;
+    }
+}

--- a/src/data/usecase/steps/link_pull_request_project_use_case.ts
+++ b/src/data/usecase/steps/link_pull_request_project_use_case.ts
@@ -22,13 +22,33 @@ export class LinkPullRequestProjectUseCase implements ParamUseCase<Execution, Re
                     param.tokens.tokenPat
                 )
                 if (actionDone) {
+
+                    let currentProject = await this.projectRepository.getProjectDetail(
+                        project.url,
+                        param.tokens.tokenPat,
+                    )
+
+                    if (currentProject === undefined) {
+                        result.push(
+                            new Result({
+                                id: this.taskId,
+                                success: false,
+                                executed: true,
+                                steps: [
+                                    `Tried to link the pull request to [\`${project.url}\`](${project.url}) but there was a problem.`,
+                                ]
+                            })
+                        )
+                        continue;
+                    }
+
                     result.push(
                         new Result({
                             id: this.taskId,
                             success: true,
                             executed: true,
                             steps: [
-                                `The pull request was linked to \`${project.url}\`.`,
+                                `The pull request was linked to [**${currentProject?.title}**](${currentProject?.url}).`,
                             ],
                             error: error,
                         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ async function run(): Promise<void> {
      * Pull Request
      */
     const pullRequestDesiredAssigneesCount = parseInt(core.getInput('desired-assignees-count')) ?? 0;
+    const pullRequestDesiredReviewersCount = parseInt(core.getInput('desired-reviewers-count')) ?? 0;
 
 
     const execution = new Execution(
@@ -134,6 +135,7 @@ async function run(): Promise<void> {
         ),
         new PullRequest(
             pullRequestDesiredAssigneesCount,
+            pullRequestDesiredReviewersCount
         ),
         new Emoji(
             titleEmoji,


### PR DESCRIPTION
- Added `desired-reviewers-count`
- Added logic to assig reviewers to a PR



<!-- GIT-BOARD-CONFIG-START 
{
    "results": [
        {
            "id": "AssignMemberToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "reminders": []
        },
        {
            "id": "AssignReviewersToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "@elisalopez was requested to review the pull request."
            ],
            "reminders": []
        },
        {
            "id": "LinkPullRequestProjectUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request was linked to [**Landa Messenger Development**](https://github.com/orgs/landamessenger/projects/2)."
            ],
            "reminders": []
        }
    ],
    "branchType": "feature"
}
GIT-BOARD-CONFIG-END -->