### PR TITLE
[#151] 🐛 - Release branch created twice

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37282,11 +37282,22 @@ class BranchRepository {
         };
         this.getListOfBranches = async (owner, repository, token) => {
             const octokit = github.getOctokit(token);
-            const { data } = await octokit.rest.repos.listBranches({
-                owner: owner,
-                repo: repository,
-            });
-            return data.map(branch => branch.name);
+            const allBranches = [];
+            let page = 1;
+            while (true) {
+                const { data } = await octokit.rest.repos.listBranches({
+                    owner: owner,
+                    repo: repository,
+                    per_page: 100,
+                    page: page,
+                });
+                if (data.length === 0) {
+                    break;
+                }
+                allBranches.push(...data.map(branch => branch.name));
+                page++;
+            }
+            return allBranches;
         };
         this.executeWorkflow = async (owner, repository, branch, workflow, inputs, token) => {
             const octokit = github.getOctokit(token);
@@ -40273,11 +40284,13 @@ class DeployAddedUseCase {
                         .replace(/-+/g, '-')
                         .trim();
                     const description = param.issue.body?.match(/### Changelog\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
+                    // Escape newlines for GitHub Actions workflow
+                    const escapedDescription = description.replace(/\n/g, '\\n');
                     const releaseUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.release.branch}`;
                     const parameters = {
                         version: param.release.version,
                         title: sanitizedTitle,
-                        changelog: description,
+                        changelog: escapedDescription,
                         issue: `${param.issue.number}`,
                     };
                     await this.branchRepository.executeWorkflow(param.owner, param.repo, param.release.branch, param.workflows.release, parameters, param.tokens.tokenPat);

--- a/src/data/repository/branch_repository.ts
+++ b/src/data/repository/branch_repository.ts
@@ -420,11 +420,26 @@ export class BranchRepository {
         token: string
     ): Promise<string[]> => {
         const octokit = github.getOctokit(token);
-        const {data} = await octokit.rest.repos.listBranches({
-            owner: owner,
-            repo: repository,
-        });
-        return data.map(branch => branch.name);
+        const allBranches = [];
+        let page = 1;
+        
+        while (true) {
+            const {data} = await octokit.rest.repos.listBranches({
+                owner: owner,
+                repo: repository,
+                per_page: 100,
+                page: page,
+            });
+            
+            if (data.length === 0) {
+                break;
+            }
+            
+            allBranches.push(...data.map(branch => branch.name));
+            page++;
+        }
+        
+        return allBranches;
     }
 
     executeWorkflow = async (

--- a/src/data/usecase/steps/label_deploy_added_use_case.ts
+++ b/src/data/usecase/steps/label_deploy_added_use_case.ts
@@ -29,12 +29,14 @@ export class DeployAddedUseCase implements ParamUseCase<Execution, Result[]> {
                         .trim();
 
                     const description = param.issue.body?.match(/### Changelog\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
+                    // Escape newlines for GitHub Actions workflow
+                    const escapedDescription = description.replace(/\n/g, '\\n');
                     
                     const releaseUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.release.branch}`;
                     const parameters = {
                         version: param.release.version,
                         title: sanitizedTitle,
-                        changelog: description,
+                        changelog: escapedDescription,
                         issue: `${param.issue.number}`,
                     }
                     await this.branchRepository.executeWorkflow(


### PR DESCRIPTION

#151

## What does this PR do?

The issue is that the release branch is being created twice on release issues. When creating a release issue and adding the `deploy` label later, the branch is created again. This behavior is only seen on the `develop` version of git-board-flow.

## What files were changed?

- `dist/index.js`: The changes in the file involve modifications to the getListOfBranches function within the BranchRepository class. The update includes a change in logic to fetch all branches using pagination and store them in an array. Additionally, modifications are made to handle and format descriptions for release notes within the DeployAddedUseCase class. Newlines are escaped for GitHub Actions workflow, ensuring proper formatting.

- `src/data/repository/branch_repository.ts`: The changes in the file involve modifying the method within the BranchRepository class that retrieves a list of branches from a GitHub repository. The code was updated to retrieve branches in batches of 100 to improve efficiency. Instead of returning the branches directly, the method now collects all branches into an array before returning them. The changes result in a decrease in 5 lines of code and an addition of 20 lines of code.

- `src/data/usecase/steps/label_deploy_added_use_case.ts`: Added 3 lines and removed 1 line from the file src/data/usecase/steps/label_deploy_added_use_case.ts. The changes involve adding an escape for newlines for a GitHub Actions workflow and updating how the changelog is handled in the code.




<!-- git-board-flow-configuration-start
{
    "results": [
        {
            "id": "UpdateTitleUseCase",
            "success": true,
            "executed": false,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignMemberToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignReviewersToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "UpdatePullRequestDescriptionUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description has been updated with AI-generated content."
            ],
            "errors": [],
            "reminders": []
        }
    ],
    "branchType": "bugfix"
}
git-board-flow-configuration-end -->