### PR TITLE
[#151] 🐛 - Release branch created twice

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40284,7 +40284,6 @@ class DeployAddedUseCase {
                         .replace(/-+/g, '-')
                         .trim();
                     const description = param.issue.body?.match(/### Changelog\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
-                    // Escape newlines for GitHub Actions workflow
                     const escapedDescription = description.replace(/\n/g, '\\n');
                     const releaseUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.release.branch}`;
                     const parameters = {
@@ -40317,11 +40316,12 @@ ${(0, content_utils_1.injectJsonAsMarkdownBlock)('Workflow Parameters', paramete
                         .replace(/-+/g, '-')
                         .trim();
                     const description = param.issue.body?.match(/### Hotfix Solution\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
+                    const escapedDescription = description.replace(/\n/g, '\\n');
                     const hotfixUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.hotfix.branch}`;
                     const parameters = {
                         version: param.hotfix.version,
                         title: sanitizedTitle,
-                        changelog: description,
+                        changelog: escapedDescription,
                         issue: param.issue.number,
                     };
                     await this.branchRepository.executeWorkflow(param.owner, param.repo, param.hotfix.branch, param.workflows.release, parameters, param.tokens.tokenPat);

--- a/src/data/usecase/steps/label_deploy_added_use_case.ts
+++ b/src/data/usecase/steps/label_deploy_added_use_case.ts
@@ -29,7 +29,6 @@ export class DeployAddedUseCase implements ParamUseCase<Execution, Result[]> {
                         .trim();
 
                     const description = param.issue.body?.match(/### Changelog\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
-                    // Escape newlines for GitHub Actions workflow
                     const escapedDescription = description.replace(/\n/g, '\\n');
                     
                     const releaseUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.release.branch}`;

--- a/src/data/usecase/steps/label_deploy_added_use_case.ts
+++ b/src/data/usecase/steps/label_deploy_added_use_case.ts
@@ -72,12 +72,13 @@ ${injectJsonAsMarkdownBlock('Workflow Parameters', parameters)}`
                         .trim();
 
                     const description = param.issue.body?.match(/### Hotfix Solution\n\n([\s\S]*?)(?=\n\n|$)/)?.[1]?.trim() ?? 'No changelog provided';
-                        
+                    const escapedDescription = description.replace(/\n/g, '\\n');
+    
                     const hotfixUrl = `https://github.com/${param.owner}/${param.repo}/tree/${param.hotfix.branch}`;
                     const parameters = {
                         version: param.hotfix.version,
                         title: sanitizedTitle,
-                        changelog: description,
+                        changelog: escapedDescription,
                         issue: param.issue.number,
                     }
                     await this.branchRepository.executeWorkflow(


### PR DESCRIPTION

#151

## What does this PR do?

The issue is related to the release branch being created twice on release issues. This occurs when a release issue is created that automatically creates the needed branch, and then the `deploy` label is added later causing the branch to be created again. This issue is currently affecting the `develop` branch.

## What files were changed?

- `dist/index.js`: In this file, modifications were made in two places. In the first change, a line of code was removed that was related to escaping newlines for GitHub Actions workflow. In the second change, a new line of code was added to escape newlines for the hotfix description. The changes involve updating how descriptions are handled in the code.

- `src/data/usecase/steps/label_deploy_added_use_case.ts`: Added new code for escaping newlines for GitHub Actions workflow and made changes to handle the description of the hotfix solution.




<!-- git-board-flow-configuration-start
{
    "results": [
        {
            "id": "UpdateTitleUseCase",
            "success": true,
            "executed": false,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignMemberToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignReviewersToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "UpdatePullRequestDescriptionUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description has been updated with AI-generated content."
            ],
            "errors": [],
            "reminders": []
        }
    ],
    "branchType": "bugfix"
}
git-board-flow-configuration-end -->