### PR TITLE
[#172] 🐛 - Missing docs and maintenance labels treatment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,9 +23,15 @@ inputs:
   docs-label:
     description: "Label to manage docs branches."
     default: "docs"
+  documentation-label:
+    description: "Label to manage docs branches."
+    default: "documentation"
   chore-label:
     description: "Label to manage chore branches."
     default: "chore"
+  maintenance-label:
+    description: "Label to manage chore branches."
+    default: "maintenance"
   hotfix-label:
     description: "Label to manage hotfix branches."
     default: "hotfix"

--- a/dist/index.js
+++ b/dist/index.js
@@ -36249,10 +36249,10 @@ class Execution {
         return this.isIssue && !this.isBranched;
     }
     get managementBranch() {
-        return (0, label_utils_1.branchesForManagement)(this, this.labels.currentIssueLabels, this.labels.bugfix, this.labels.hotfix, this.labels.release, this.labels.docs, this.labels.chore);
+        return (0, label_utils_1.branchesForManagement)(this, this.labels.currentIssueLabels, this.labels.feature, this.labels.enhancement, this.labels.bugfix, this.labels.bug, this.labels.hotfix, this.labels.release, this.labels.docs, this.labels.documentation, this.labels.chore, this.labels.maintenance);
     }
     get issueType() {
-        return (0, label_utils_1.typesForIssue)(this, this.labels.currentIssueLabels, this.labels.bugfix, this.labels.hotfix, this.labels.release, this.labels.docs, this.labels.chore);
+        return (0, label_utils_1.typesForIssue)(this, this.labels.currentIssueLabels, this.labels.feature, this.labels.enhancement, this.labels.bugfix, this.labels.bug, this.labels.hotfix, this.labels.release, this.labels.docs, this.labels.documentation, this.labels.chore, this.labels.maintenance);
     }
     get cleanIssueBranches() {
         return this.isIssue
@@ -36578,10 +36578,16 @@ class Labels {
     get isDocs() {
         return this.currentIssueLabels.includes(this.docs);
     }
+    get isDocumentation() {
+        return this.currentIssueLabels.includes(this.documentation);
+    }
     get isChore() {
         return this.currentIssueLabels.includes(this.chore);
     }
-    constructor(branchManagementLauncherLabel, bug, bugfix, hotfix, enhancement, feature, release, question, help, deploy, deployed, docs, chore) {
+    get isMaintenance() {
+        return this.currentIssueLabels.includes(this.maintenance);
+    }
+    constructor(branchManagementLauncherLabel, bug, bugfix, hotfix, enhancement, feature, release, question, help, deploy, deployed, docs, documentation, chore, maintenance) {
         this.currentIssueLabels = [];
         this.currentPullRequestLabels = [];
         this.branchManagementLauncherLabel = branchManagementLauncherLabel;
@@ -36596,7 +36602,9 @@ class Labels {
         this.deploy = deploy;
         this.deployed = deployed;
         this.docs = docs;
+        this.documentation = documentation;
         this.chore = chore;
+        this.maintenance = maintenance;
     }
 }
 exports.Labels = Labels;
@@ -37559,10 +37567,10 @@ class IssueRepository {
                 else if ((labels.isFeature || labels.isEnhancement) && branched) {
                     emoji = `✨${branchManagementEmoji}`;
                 }
-                else if (labels.isDocs && branched) {
+                else if ((labels.isDocs || labels.isDocumentation) && branched) {
                     emoji = `📝${branchManagementEmoji}`;
                 }
-                else if (labels.isChore && branched) {
+                else if ((labels.isChore || labels.isMaintenance) && branched) {
                     emoji = `🔧${branchManagementEmoji}`;
                 }
                 else if (labels.isHotfix) {
@@ -37571,10 +37579,10 @@ class IssueRepository {
                 else if (labels.isRelease) {
                     emoji = '🚀';
                 }
-                else if (labels.isDocs) {
+                else if ((labels.isDocs || labels.isDocumentation)) {
                     emoji = '📝';
                 }
-                else if (labels.isChore) {
+                else if (labels.isChore || labels.isMaintenance) {
                     emoji = '🔧';
                 }
                 else if (labels.isBugfix || labels.isBug) {
@@ -41695,31 +41703,35 @@ exports.injectJsonAsMarkdownBlock = injectJsonAsMarkdownBlock;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.typesForIssue = exports.branchesForManagement = void 0;
-const branchesForManagement = (params, labels, bugfixLabel, hotfixLabel, releaseLabel, docsLabel, choreLabel) => {
+const branchesForManagement = (params, labels, featureLabel, enhancementLabel, bugfixLabel, bugLabel, hotfixLabel, releaseLabel, docsLabel, documentationLabel, choreLabel, maintenanceLabel) => {
     if (labels.includes(hotfixLabel))
         return params.branches.bugfixTree;
-    if (labels.includes(bugfixLabel))
+    if (labels.includes(bugfixLabel) || labels.includes(bugLabel))
         return params.branches.bugfixTree;
     if (labels.includes(releaseLabel))
         return params.branches.releaseTree;
-    if (labels.includes(docsLabel))
+    if (labels.includes(docsLabel) || labels.includes(documentationLabel))
         return params.branches.docsTree;
-    if (labels.includes(choreLabel))
+    if (labels.includes(choreLabel) || labels.includes(maintenanceLabel))
         return params.branches.choreTree;
+    if (labels.includes(featureLabel) || labels.includes(enhancementLabel))
+        return params.branches.featureTree;
     return params.branches.featureTree;
 };
 exports.branchesForManagement = branchesForManagement;
-const typesForIssue = (params, labels, bugfixLabel, hotfixLabel, releaseLabel, docsLabel, choreLabel) => {
+const typesForIssue = (params, labels, featureLabel, enhancementLabel, bugfixLabel, bugLabel, hotfixLabel, releaseLabel, docsLabel, documentationLabel, choreLabel, maintenanceLabel) => {
     if (labels.includes(hotfixLabel))
         return params.branches.hotfixTree;
-    if (labels.includes(bugfixLabel))
+    if (labels.includes(bugfixLabel) || labels.includes(bugLabel))
         return params.branches.bugfixTree;
     if (labels.includes(releaseLabel))
         return params.branches.releaseTree;
-    if (labels.includes(docsLabel))
+    if (labels.includes(docsLabel) || labels.includes(documentationLabel))
         return params.branches.docsTree;
-    if (labels.includes(choreLabel))
+    if (labels.includes(choreLabel) || labels.includes(maintenanceLabel))
         return params.branches.choreTree;
+    if (labels.includes(featureLabel) || labels.includes(enhancementLabel))
+        return params.branches.featureTree;
     return params.branches.featureTree;
 };
 exports.typesForIssue = typesForIssue;
@@ -42074,7 +42086,9 @@ async function run() {
     const deployLabel = core.getInput('deploy-label');
     const deployedLabel = core.getInput('deployed-label');
     const docsLabel = core.getInput('docs-label');
+    const documentationLabel = core.getInput('documentation-label');
     const choreLabel = core.getInput('chore-label');
+    const maintenanceLabel = core.getInput('maintenance-label');
     /**
      * Branches
      */
@@ -42102,7 +42116,7 @@ async function run() {
     const pullRequestDesiredAssigneesCount = parseInt(core.getInput('desired-assignees-count')) ?? 0;
     const pullRequestDesiredReviewersCount = parseInt(core.getInput('desired-reviewers-count')) ?? 0;
     const pullRequestMergeTimeout = parseInt(core.getInput('merge-timeout')) ?? 0;
-    const execution = new execution_1.Execution(new single_action_1.SingleAction(singleAction, singleActionIssue), commitPrefixBuilder, new issue_1.Issue(branchManagementAlways, reopenIssueOnPush, issueDesiredAssigneesCount), new pull_request_1.PullRequest(pullRequestDesiredAssigneesCount, pullRequestDesiredReviewersCount, pullRequestMergeTimeout), new emoji_1.Emoji(titleEmoji, branchManagementEmoji), new images_1.Images(imagesIssueAutomatic, imagesIssueFeature, imagesIssueBugfix, imagesIssueDocs, imagesIssueChore, imagesIssueRelease, imagesIssueHotfix, imagesPullRequestAutomatic), new tokens_1.Tokens(token, tokenPat), new ai_1.Ai(openaiApiKey, aiPullRequestDescription, aiMembersOnly, aiIgnoreFiles), new labels_1.Labels(branchManagementLauncherLabel, bugLabel, bugfixLabel, hotfixLabel, enhancementLabel, featureLabel, releaseLabel, questionLabel, helpLabel, deployLabel, deployedLabel, docsLabel, choreLabel), new branches_1.Branches(mainBranch, developmentBranch, featureTree, bugfixTree, hotfixTree, releaseTree, docsTree, choreTree), new release_1.Release(), new hotfix_1.Hotfix(), new workflows_1.Workflows(releaseWorkflow, hotfixWorkflow), projects);
+    const execution = new execution_1.Execution(new single_action_1.SingleAction(singleAction, singleActionIssue), commitPrefixBuilder, new issue_1.Issue(branchManagementAlways, reopenIssueOnPush, issueDesiredAssigneesCount), new pull_request_1.PullRequest(pullRequestDesiredAssigneesCount, pullRequestDesiredReviewersCount, pullRequestMergeTimeout), new emoji_1.Emoji(titleEmoji, branchManagementEmoji), new images_1.Images(imagesIssueAutomatic, imagesIssueFeature, imagesIssueBugfix, imagesIssueDocs, imagesIssueChore, imagesIssueRelease, imagesIssueHotfix, imagesPullRequestAutomatic), new tokens_1.Tokens(token, tokenPat), new ai_1.Ai(openaiApiKey, aiPullRequestDescription, aiMembersOnly, aiIgnoreFiles), new labels_1.Labels(branchManagementLauncherLabel, bugLabel, bugfixLabel, hotfixLabel, enhancementLabel, featureLabel, releaseLabel, questionLabel, helpLabel, deployLabel, deployedLabel, docsLabel, documentationLabel, choreLabel, maintenanceLabel), new branches_1.Branches(mainBranch, developmentBranch, featureTree, bugfixTree, hotfixTree, releaseTree, docsTree, choreTree), new release_1.Release(), new hotfix_1.Hotfix(), new workflows_1.Workflows(releaseWorkflow, hotfixWorkflow), projects);
     await execution.setup();
     if (execution.issueNumber === -1) {
         core.info(`Issue number not found. Skipping.`);

--- a/src/data/model/execution.ts
+++ b/src/data/model/execution.ts
@@ -108,11 +108,16 @@ export class Execution {
         return branchesForManagement(
             this,
             this.labels.currentIssueLabels,
+            this.labels.feature,
+            this.labels.enhancement,
             this.labels.bugfix,
+            this.labels.bug,
             this.labels.hotfix,
             this.labels.release,
             this.labels.docs,
+            this.labels.documentation,
             this.labels.chore,
+            this.labels.maintenance,
         );
     }
 
@@ -120,11 +125,16 @@ export class Execution {
         return typesForIssue(
             this,
             this.labels.currentIssueLabels,
+            this.labels.feature,
+            this.labels.enhancement,
             this.labels.bugfix,
+            this.labels.bug,
             this.labels.hotfix,
             this.labels.release,
             this.labels.docs,
+            this.labels.documentation,
             this.labels.chore,
+            this.labels.maintenance,
         );
     }
 

--- a/src/data/model/labels.ts
+++ b/src/data/model/labels.ts
@@ -11,7 +11,9 @@ export class Labels {
     deploy: string;
     deployed: string;
     docs: string;
+    documentation: string;
     chore: string;
+    maintenance: string;
     currentIssueLabels: string[] = [];
     currentPullRequestLabels: string[] = [];
 
@@ -67,8 +69,16 @@ export class Labels {
         return this.currentIssueLabels.includes(this.docs);
     }
 
+    get isDocumentation(): boolean {
+        return this.currentIssueLabels.includes(this.documentation);
+    }
+
     get isChore(): boolean {
         return this.currentIssueLabels.includes(this.chore);
+    }
+
+    get isMaintenance(): boolean {
+        return this.currentIssueLabels.includes(this.maintenance);
     }
 
     constructor(
@@ -84,7 +94,9 @@ export class Labels {
         deploy: string,
         deployed: string,
         docs: string,
+        documentation: string,
         chore: string,
+        maintenance: string,
     ) {
         this.branchManagementLauncherLabel = branchManagementLauncherLabel;
         this.bug = bug;
@@ -98,6 +110,8 @@ export class Labels {
         this.deploy = deploy;
         this.deployed = deployed;
         this.docs = docs;
+        this.documentation = documentation;
         this.chore = chore;
+        this.maintenance = maintenance;
     }
 }

--- a/src/data/repository/issue_repository.ts
+++ b/src/data/repository/issue_repository.ts
@@ -31,17 +31,17 @@ export class IssueRepository {
                 emoji = `🐛${branchManagementEmoji}`;
             } else if ((labels.isFeature || labels.isEnhancement) && branched) {
                 emoji = `✨${branchManagementEmoji}`;
-            } else if (labels.isDocs && branched) {
+            } else if ((labels.isDocs || labels.isDocumentation) && branched) {
                 emoji = `📝${branchManagementEmoji}`;
-            } else if (labels.isChore && branched) {
+            } else if ((labels.isChore || labels.isMaintenance) && branched) {
                 emoji = `🔧${branchManagementEmoji}`;
             } else if (labels.isHotfix) {
                 emoji = '🔥';
             } else if (labels.isRelease) {
                 emoji = '🚀';
-            } else if (labels.isDocs) {
+            } else if ((labels.isDocs || labels.isDocumentation)) {
                 emoji = '📝';
-            } else if (labels.isChore) {
+            } else if (labels.isChore || labels.isMaintenance) {
                 emoji = '🔧';
             } else if (labels.isBugfix || labels.isBug) {
                 emoji = '🐛';

--- a/src/data/utils/label_utils.ts
+++ b/src/data/utils/label_utils.ts
@@ -3,33 +3,45 @@ import {Execution} from "../model/execution";
 export const branchesForManagement = (
     params: Execution,
     labels: string[],
+    featureLabel: string,
+    enhancementLabel: string,
     bugfixLabel: string,
+    bugLabel: string,
     hotfixLabel: string,
     releaseLabel: string,
     docsLabel: string,
+    documentationLabel: string,
     choreLabel: string,
+    maintenanceLabel: string,
 ): string => {
     if (labels.includes(hotfixLabel)) return params.branches.bugfixTree;
-    if (labels.includes(bugfixLabel)) return params.branches.bugfixTree;
+    if (labels.includes(bugfixLabel) || labels.includes(bugLabel)) return params.branches.bugfixTree;
     if (labels.includes(releaseLabel)) return params.branches.releaseTree;
-    if (labels.includes(docsLabel)) return params.branches.docsTree;
-    if (labels.includes(choreLabel)) return params.branches.choreTree;
+    if (labels.includes(docsLabel) || labels.includes(documentationLabel)) return params.branches.docsTree;
+    if (labels.includes(choreLabel) || labels.includes(maintenanceLabel)) return params.branches.choreTree;
+    if (labels.includes(featureLabel) || labels.includes(enhancementLabel)) return params.branches.featureTree;
     return params.branches.featureTree;
 }
 
 export const typesForIssue = (
     params: Execution,
     labels: string[],
+    featureLabel: string,
+    enhancementLabel: string,
     bugfixLabel: string,
+    bugLabel: string,
     hotfixLabel: string,
     releaseLabel: string,
     docsLabel: string,
+    documentationLabel: string,
     choreLabel: string,
+    maintenanceLabel: string,
 ): string => {
     if (labels.includes(hotfixLabel)) return params.branches.hotfixTree;
-    if (labels.includes(bugfixLabel)) return params.branches.bugfixTree;
+    if (labels.includes(bugfixLabel) || labels.includes(bugLabel)) return params.branches.bugfixTree;
     if (labels.includes(releaseLabel)) return params.branches.releaseTree;
-    if (labels.includes(docsLabel)) return params.branches.docsTree;
-    if (labels.includes(choreLabel)) return params.branches.choreTree;
+    if (labels.includes(docsLabel) || labels.includes(documentationLabel)) return params.branches.docsTree;
+    if (labels.includes(choreLabel) || labels.includes(maintenanceLabel)) return params.branches.choreTree;
+    if (labels.includes(featureLabel) || labels.includes(enhancementLabel)) return params.branches.featureTree;
     return params.branches.featureTree;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,9 @@ async function run(): Promise<void> {
     const deployLabel = core.getInput('deploy-label');
     const deployedLabel = core.getInput('deployed-label');
     const docsLabel = core.getInput('docs-label');
+    const documentationLabel = core.getInput('documentation-label');
     const choreLabel = core.getInput('chore-label');
+    const maintenanceLabel = core.getInput('maintenance-label');
 
     /**
      * Branches
@@ -228,7 +230,9 @@ async function run(): Promise<void> {
             deployLabel,
             deployedLabel,
             docsLabel,
+            documentationLabel,
             choreLabel,
+            maintenanceLabel,
         ),
         new Branches(
             mainBranch,


### PR DESCRIPTION

#172

## What does this PR do?

Fixed the issue with missing labels `documentation` and `maintenance` by updating the title and creating a new branch for bugfix/172-missing-docs-and-maintenance-labels-treatment.

## What files were changed?

- `action.yml`: Added two new inputs for "documentation-label" and "maintenance-label" with default values, both used to manage branches. The "documentation-label" is set to "documentation" and the "maintenance-label" is set to "maintenance". These changes were made to the inputs section of the file.

- `dist/index.js`: The changes in the file include modifications to the `managementBranch` and `issueType` getters in the `Execution` class to include additional labels such as `feature`, `enhancement`, `documentation`, and `maintenance`. The `Labels` class constructor was updated to include parameters for `documentation` and `maintenance`. The `IssueRepository` class logic was modified to consider `documentation` and `maintenance` labels along with existing labels for emojis. The `branchesForManagement` and `typesForIssue` functions were updated to handle new labels. Additionally, the `run` function was adjusted to include inputs for `documentation-label` and `maintenance-label`, with corresponding updates to the `Execution` class instantiation.

- `src/data/model/execution.ts`: Added handling for labels "feature", "enhancement", "bug", "documentation", and "maintenance" in the branchesForManagement and typesForIssue methods in the Execution class. Total of 10 lines added, 0 lines removed.

- `src/data/model/labels.ts`: - Added a new property 'documentation' in the class Labels
- Added a new property 'maintenance' in the class Labels
- Added a new method 'isDocumentation' to check if a current issue includes 'documentation'
- Added a new method 'isMaintenance' to check if a current issue includes 'maintenance'

- `src/data/repository/issue_repository.ts`: In the file src/data/repository/issue_repository.ts, there were modifications made to the code. Specifically, there were changes in the conditions for assigning emojis based on labels and whether a branch exists. Labels such as "isDocs" and "isChore" were updated to include additional options like "isDocumentation" and "isMaintenance". This change ensures that the correct emoji is assigned based on the label and branch status.

- `src/data/utils/label_utils.ts`: Added new parameters `featureLabel`, `enhancementLabel`, `bugLabel`, `documentationLabel`, and `maintenanceLabel` to the functions `branchesForManagement` and `typesForIssue`. Updated the logic in the functions to consider these new labels when determining the branches for management and types for the issue.

- `src/index.ts`: Added two new variables `documentationLabel` and `maintenanceLabel`, and included them in the implementation of the Branches class.




<!-- git-board-flow-configuration-start
{
    "results": [
        {
            "id": "UpdateTitleUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request's title was updated from `Bugfix/172 missing docs and maintenance labels treatment` to `[#172] 🐛 - Missing docs and maintenance labels treatment`."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignMemberToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request was assigned to @efraespada (creator)."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignMemberToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [],
            "errors": [],
            "reminders": []
        },
        {
            "id": "AssignReviewersToIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "@elisalopez was requested to review the pull request."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "LinkPullRequestProjectUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The pull request was linked to [**Landa Messenger Development**](https://github.com/orgs/landamessenger/projects/2)."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was temporarily updated to `master`."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description was temporarily modified to include a reference to issue **#172**."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The base branch was reverted to its original value: `develop`."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "LinkPullRequestIssueUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The temporary issue reference **#172** was removed from the description."
            ],
            "errors": [],
            "reminders": []
        },
        {
            "id": "UpdatePullRequestDescriptionUseCase",
            "success": true,
            "executed": true,
            "steps": [
                "The description has been updated with AI-generated content."
            ],
            "errors": [],
            "reminders": []
        }
    ],
    "branchType": "bugfix"
}
git-board-flow-configuration-end -->